### PR TITLE
refactor: replace SQL Event Store with EventStore implementation

### DIFF
--- a/14. EventSourcingSample/Ms.EventSourcingSample.Domain/Products/Entities/Product.cs
+++ b/14. EventSourcingSample/Ms.EventSourcingSample.Domain/Products/Entities/Product.cs
@@ -28,7 +28,7 @@ public class Product : AggregateRoot
         Apply(new NameChanged(Id, newName));
     }
 
-    public void On(ProductCreated productCreated)
+    private void On(ProductCreated productCreated)
     {
         Id = productCreated.Id;
         Name = productCreated.Name;
@@ -36,12 +36,12 @@ public class Product : AggregateRoot
         Price = productCreated.Price;
     }
 
-    public void On(PriceChanged priceChanged)
+    private void On(PriceChanged priceChanged)
     {
         Price = priceChanged.Price;
     }
 
-    public void On(NameChanged nameChanged)
+    private void On(NameChanged nameChanged)
     {
         Name = nameChanged.Name;
     }

--- a/14. EventSourcingSample/Ms.EventSourcingSample.Endpoint/Program.cs
+++ b/14. EventSourcingSample/Ms.EventSourcingSample.Endpoint/Program.cs
@@ -10,7 +10,7 @@ builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
-builder.Services.AddScoped<IEventStore, SqlEventStore>();
+builder.Services.AddScoped<IEventStore, EsEvenStore>();
 builder.Services.AddScoped<IProductRepository, ProductRepository>();
 
 var app = builder.Build();

--- a/14. EventSourcingSample/Ms.EventSourcingSample.Framework/AggregateRoot.cs
+++ b/14. EventSourcingSample/Ms.EventSourcingSample.Framework/AggregateRoot.cs
@@ -1,4 +1,6 @@
-﻿namespace Ms.EventSourcingSample.Framework;
+﻿using System.Reflection;
+
+namespace Ms.EventSourcingSample.Framework;
 
 public class AggregateRoot : Entity
 {
@@ -18,7 +20,7 @@ public class AggregateRoot : Entity
 
     public AggregateRoot()
     {
-        
+
     }
     public AggregateRoot(IReadOnlyList<IDomainEvent> domainEvents)
     {
@@ -34,7 +36,13 @@ public class AggregateRoot : Entity
         }
 
     }
-    private void Mutate(IDomainEvent @event) => ((dynamic)this).On((dynamic)@event);
+    private void Mutate(IDomainEvent @event)
+    {
+        //((dynamic)this).On((dynamic)@event);
+        var onMethod = this.GetType()
+            .GetMethod("On", BindingFlags.Instance | BindingFlags.NonPublic, [@event.GetType()]);
+        onMethod.Invoke(this, [@event]);
+    }
 
     public void ClearEvent()
     {

--- a/14. EventSourcingSample/Ms.EventSourcingSample.Framework/EsEvenStore.cs
+++ b/14. EventSourcingSample/Ms.EventSourcingSample.Framework/EsEvenStore.cs
@@ -1,0 +1,64 @@
+﻿using EventStore.Client;
+
+using Newtonsoft.Json;
+
+namespace Ms.EventSourcingSample.Framework;
+
+public class EsEvenStore : IEventStore
+{
+    private readonly EventStoreClient _client;
+    private readonly JsonSerializerSettings _jsonSerializerSettings = new()
+    {
+        TypeNameHandling = TypeNameHandling.All,
+        NullValueHandling = NullValueHandling.Ignore,
+    };
+
+    public EsEvenStore()
+    { 
+        const string connectionString = "esdb://admin:changeit@127.0.0.1:2113?tls=true&keepAliveTimeout=10000&keepAliveInterval=10000&tlsVerifyCert=false";
+        var settings = EventStoreClientSettings.Create(connectionString);
+        _client = new EventStoreClient(settings);
+    }
+    public async void Save(string aggregateTypeName, long id, int currentVersion,
+        IReadOnlyList<IDomainEvent> domainEvents)
+    {
+        IEnumerable<EventData> eventData = domainEvents.Select(c =>
+            new EventData(Uuid.NewUuid(), c.GetType().Name, GetSerializedEventData(c)));
+        await _client.AppendToStreamAsync(
+            StreamId(aggregateTypeName, id),
+            StreamState.Any,
+            eventData);
+    }
+
+    private ReadOnlyMemory<byte> GetSerializedEventData(IDomainEvent @event)
+    {
+        var jsonEvent = JsonConvert.SerializeObject(@event, _jsonSerializerSettings);
+        var byteArray= System.Text.Encoding.UTF8.GetBytes(jsonEvent);
+        return byteArray;
+    }
+
+    public IReadOnlyList<IDomainEvent> Get(string aggregateTypeName, long id)
+    {
+        var result = _client.ReadStreamAsync(
+            Direction.Forwards,
+            StreamId(aggregateTypeName, id),
+            StreamPosition.Start);
+
+        var events = result.ToListAsync(CancellationToken.None).Result;
+        var domainEvent = events.Select(e => GetDomainEvent(e.Event.Data.ToArray())).ToList();
+        return domainEvent;
+    }
+
+    private IDomainEvent GetDomainEvent(byte[] data)
+    {
+        var str = System.Text.Encoding.UTF8.GetString(data);
+        var myObject = JsonConvert.DeserializeObject(str, _jsonSerializerSettings);
+        var domainEvent = myObject as IDomainEvent;
+        return domainEvent;
+    }
+
+    private string StreamId(string aggregateTypeName, long id)
+    {
+        return $"{aggregateTypeName}-{id}";
+    }
+}

--- a/14. EventSourcingSample/Ms.EventSourcingSample.Framework/Ms.EventSourcingSample.Framework.csproj
+++ b/14. EventSourcingSample/Ms.EventSourcingSample.Framework/Ms.EventSourcingSample.Framework.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="EventStore.Client.Grpc.Streams" Version="23.2.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/14. EventSourcingSample/Ms.EventSourcingSample.Framework/SqlEventStore.cs
+++ b/14. EventSourcingSample/Ms.EventSourcingSample.Framework/SqlEventStore.cs
@@ -26,7 +26,7 @@ public class SqlEventStore : IEventStore
     };
     private readonly IDbConnection _db = new SqlConnection(
         "Server=.; Initial Catalog=Microservice_EventSourcing; User Id=masoud; Password=M@$$0ud1001;Encrypt=False;Trust Server Certificate=False;");
-    public void Save(string aggregateTypeName, long id,int currentVersion, IReadOnlyList<IDomainEvent> domainEvents)
+    public void Save(string aggregateTypeName, long id, int currentVersion, IReadOnlyList<IDomainEvent> domainEvents)
     {
         string insertCommand = """
                                INSERT INTO [dbo].[EventStore]


### PR DESCRIPTION
Replaced the SQL Event Store implementation with a new EventStore implementation
called EsEvenStore for better performance and scalability in the application.